### PR TITLE
Update PostProvisioningTask.java

### DIFF
--- a/app/src/main/java/com/afwsamples/testdpc/provision/PostProvisioningTask.java
+++ b/app/src/main/java/com/afwsamples/testdpc/provision/PostProvisioningTask.java
@@ -89,7 +89,9 @@ public class PostProvisioningTask {
         // From M onwards, permissions are not auto-granted, so we need to manually grant
         // permissions for TestDPC.
         if (Util.isAtLeastM()) {
-            autoGrantRequestedPermissionsToSelf();
+            new Thread(()-> {
+                autoGrantRequestedPermissionsToSelf();
+            }).start();
         }
 
         // Retreive the admin extras bundle, which we can use to determine the original context for


### PR DESCRIPTION
Sometimes DPM.setPermissionGrantState could cause ANR in case of calling this API in main thread
(See the DevicePolicyManager.java code on AOSP, the DPM API waits for the complete of Future with 20 sec in maximum)